### PR TITLE
Add `merge` option to all Agents

### DIFF
--- a/lib/huginn_dkt_curation_agents/concerns/dkt_nif_api_agent_concern.rb
+++ b/lib/huginn_dkt_curation_agents/concerns/dkt_nif_api_agent_concern.rb
@@ -49,6 +49,8 @@ module DktNifApiAgentConcern
              response.body
            end
 
-    create_event payload: { body: body, headers: response.headers, status: response.status }
+    original_payload = boolify(mo['merge']) ? options[:event].payload : {}
+
+    create_event payload: original_payload.merge(body: body, headers: response.headers, status: response.status)
   end
 end

--- a/lib/huginn_dkt_curation_agents/concerns/dkt_nif_api_agent_concern.rb
+++ b/lib/huginn_dkt_curation_agents/concerns/dkt_nif_api_agent_concern.rb
@@ -1,6 +1,21 @@
 module DktNifApiAgentConcern
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def common_nif_agent_fields
+      form_configurable :merge, type: :boolean
+      form_configurable :result_key
+    end
+
+    def common_nif_agent_fields_description
+      Utils.unindent <<-MD
+        `merge` set to `true` to retain the received payload and update it with the extracted result
+
+        `result_key` when present the emitted Event data will be nested inside the specified key
+      MD
+    end
+  end
+
   included do
     can_dry_run!
 
@@ -49,8 +64,13 @@ module DktNifApiAgentConcern
              response.body
            end
 
-    original_payload = boolify(mo['merge']) ? options[:event].payload : {}
+    create_nif_event!(mo, options[:event], body: body, headers: response.headers, status: response.status)
+  end
 
-    create_event payload: original_payload.merge(body: body, headers: response.headers, status: response.status)
+  def create_nif_event!(mo, event, payload)
+    original_payload = boolify(mo['merge']) ? event.payload : {}
+    payload = {mo['result_key'] => payload} if mo['result_key'].present?
+
+    create_event payload: original_payload.merge(payload)
   end
 end

--- a/lib/huginn_dkt_curation_agents/dkt_clustering_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_clustering_agent.rb
@@ -27,7 +27,7 @@ module Agents
 
         `algorithm`: the algorithm to be used during clustering. Currently EM and Kmeans are supported.
 
-        `merge` set to true to retain the received payload and update it with the extracted result
+        #{common_nif_agent_fields_description}
 
         **When receiving a file pointer:**
 
@@ -50,7 +50,7 @@ module Agents
     form_configurable :body, type: :text
     form_configurable :language, type: :array, values: ['en','de']
     form_configurable :algorithm, type: :array, values: ['em', 'kmeans']
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_clustering_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_clustering_agent.rb
@@ -27,7 +27,7 @@ module Agents
 
         `algorithm`: the algorithm to be used during clustering. Currently EM and Kmeans are supported.
 
-        #{common_nif_agent_fields_description}
+        #{self.class.common_nif_agent_fields_description}
 
         **When receiving a file pointer:**
 

--- a/lib/huginn_dkt_curation_agents/dkt_clustering_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_clustering_agent.rb
@@ -27,6 +27,8 @@ module Agents
 
         `algorithm`: the algorithm to be used during clustering. Currently EM and Kmeans are supported.
 
+        `merge` set to true to retain the received payload and update it with the extracted result
+
         **When receiving a file pointer:**
 
         `body` will be ignored and the contents of the received file will be send instead.
@@ -48,6 +50,7 @@ module Agents
     form_configurable :body, type: :text
     form_configurable :language, type: :array, values: ['en','de']
     form_configurable :algorithm, type: :array, values: ['em', 'kmeans']
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -63,7 +66,7 @@ module Agents
           mo['body'] = io
         end
 
-        nif_request!(mo, ['language', 'algorithm'], mo['url'], parse_response: :json)
+        nif_request!(mo, ['language', 'algorithm'], mo['url'], parse_response: :json, event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_document_classification_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_classification_agent.rb
@@ -36,6 +36,7 @@ module Agents
 
       `modelPath` [optional] this parameter is only used is other location for models is used inside the server. This parameter has been meant for local installation of the service.
 
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -57,6 +58,7 @@ module Agents
     form_configurable :language, type: :array, values: ['de']
     form_configurable :modelName, type: :array, values: ['3pc', 'condat_types', 'condat_categories', 'kreuzwerker_categories', 'kreuzwerker_subcategories', 'kreuzwerker_topics']
     form_configurable :modelPath
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -68,7 +70,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'modelName', 'input', 'informat', 'modelPath', 'language'], mo['url'])
+        nif_request!(mo, ['outformat', 'modelName', 'input', 'informat', 'modelPath', 'language'], mo['url'], event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_document_classification_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_classification_agent.rb
@@ -36,7 +36,7 @@ module Agents
 
       `modelPath` [optional] this parameter is only used is other location for models is used inside the server. This parameter has been meant for local installation of the service.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -58,7 +58,7 @@ module Agents
     form_configurable :language, type: :array, values: ['de']
     form_configurable :modelName, type: :array, values: ['3pc', 'condat_types', 'condat_categories', 'kreuzwerker_categories', 'kreuzwerker_subcategories', 'kreuzwerker_topics']
     form_configurable :modelPath
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_document_storage_query_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_storage_query_agent.rb
@@ -19,7 +19,7 @@ module Agents
 
       `mode`:`documents` returns all documents of the collection, `status` returns the status of the collection
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -32,7 +32,7 @@ module Agents
     form_configurable :url
     form_configurable :collection_name
     form_configurable :mode, type: :array, values: ['documents', 'status']
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_document_storage_query_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_storage_query_agent.rb
@@ -18,6 +18,8 @@ module Agents
       `collection_name` Name of the collection.
 
       `mode`:`documents` returns all documents of the collection, `status` returns the status of the collection
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -30,6 +32,7 @@ module Agents
     form_configurable :url
     form_configurable :collection_name
     form_configurable :mode, type: :array, values: ['documents', 'status']
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -42,7 +45,7 @@ module Agents
         mo = interpolated(event)
 
         mo['body_format'] = mo.delete('content_type') || 'text/plain'
-        nif_request!(mo, [], mo['url'] + "/#{mo['collection_name']}/#{mo['mode']}", parse_response: :json, method: :get)
+        nif_request!(mo, [], mo['url'] + "/#{mo['collection_name']}/#{mo['mode']}", parse_response: :json, method: :get, event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_document_storage_store_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_storage_store_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
         `file_name` Name of the file uploaded.
 
-        #{common_nif_agent_fields_description}
+        #{self.class.common_nif_agent_fields_description}
 
         **When receiving a file pointer:**
 

--- a/lib/huginn_dkt_curation_agents/dkt_document_storage_store_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_storage_store_agent.rb
@@ -25,7 +25,7 @@ module Agents
 
         `file_name` Name of the file uploaded.
 
-        `merge` set to true to retain the received payload and update it with the extracted result
+        #{common_nif_agent_fields_description}
 
         **When receiving a file pointer:**
 
@@ -47,7 +47,7 @@ module Agents
     form_configurable :collection_name
     form_configurable :fileName
     form_configurable :content_type
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_document_storage_store_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_document_storage_store_agent.rb
@@ -25,6 +25,8 @@ module Agents
 
         `file_name` Name of the file uploaded.
 
+        `merge` set to true to retain the received payload and update it with the extracted result
+
         **When receiving a file pointer:**
 
         `content_type` and `file_name` can optionally be used to override the file name and content-type of the received file.
@@ -45,6 +47,7 @@ module Agents
     form_configurable :collection_name
     form_configurable :fileName
     form_configurable :content_type
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -63,10 +66,10 @@ module Agents
           logger.warn('No content-type has been set.') if mo['content_type'].blank?
           mo['body_format'] = mo.delete('content_type') || 'text/plain'
 
-          nif_request!(mo, [], mo['url'] + "/#{mo['collection_name']}?fileName=#{CGI.escape(mo['fileName'])}", headers: {'Transfer-Encoding' => 'chunked'})
+          nif_request!(mo, [], mo['url'] + "/#{mo['collection_name']}?fileName=#{CGI.escape(mo['fileName'])}", headers: {'Transfer-Encoding' => 'chunked'}, event: event)
         else
           mo['body_format'] = mo.delete('content_type') || 'text/plain'
-          nif_request!(mo, ['fileName', 'file'], mo['url'] + "/#{mo['collection_name']}")
+          nif_request!(mo, ['fileName', 'file'], mo['url'] + "/#{mo['collection_name']}", event: event)
         end
       end
     end

--- a/lib/huginn_dkt_curation_agents/dkt_logging_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_logging_agent.rb
@@ -36,6 +36,8 @@ module Agents
       `errorType`: the type of the error has not been defined for now, but it can be something like: BadRequestException, EmptyInputArgument, etc.
 
       `additionalInformation`: additional text associated with the interaction.
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -58,6 +60,7 @@ module Agents
     form_configurable :errorId
     form_configurable :errorType
     form_configurable :additionalInformation
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -73,7 +76,9 @@ module Agents
           request.params.update(mo.except('url'))
         end
 
-        create_event payload: { body: response.body, headers: response.headers, status: response.status }
+        original_payload = boolify(mo['merge']) ? event.payload : {}
+
+        create_event payload: original_payload.merge(body: response.body, headers: response.headers, status: response.status)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_logging_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_logging_agent.rb
@@ -37,7 +37,7 @@ module Agents
 
       `additionalInformation`: additional text associated with the interaction.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -60,7 +60,7 @@ module Agents
     form_configurable :errorId
     form_configurable :errorType
     form_configurable :additionalInformation
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -76,9 +76,7 @@ module Agents
           request.params.update(mo.except('url'))
         end
 
-        original_payload = boolify(mo['merge']) ? event.payload : {}
-
-        create_event payload: original_payload.merge(body: response.body, headers: response.headers, status: response.status)
+        create_nif_event!(mo, event, body: response.body, headers: response.headers, status: response.status)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_ner_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_ner_agent.rb
@@ -28,6 +28,8 @@ module Agents
       `mode`: Works for the `ner` analysis only. Possible values are spot (for entity spotting only), link (for entity linking only, e.g. looking up the entity label on DBPedia to retrieve a URI) or all (for both).
 
       `models`: Specify the model to be used for performing the analysis. Use 'manual input' to specify multiple models in a comma separated list.
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -49,6 +51,7 @@ module Agents
     form_configurable :analysis, type: :array, values: ['ner', 'dict', 'temp']
     form_configurable :mode, type: :array, values: ['all', 'spot', 'link']
     form_configurable :models, roles: :completable, cache_response: false
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -68,7 +71,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'language', 'analysis', 'models', 'mode'], mo['url'])
+        nif_request!(mo, ['outformat', 'language', 'analysis', 'models', 'mode'], mo['url'], event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_ner_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_ner_agent.rb
@@ -29,7 +29,7 @@ module Agents
 
       `models`: Specify the model to be used for performing the analysis. Use 'manual input' to specify multiple models in a comma separated list.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -51,7 +51,7 @@ module Agents
     form_configurable :analysis, type: :array, values: ['ner', 'dict', 'temp']
     form_configurable :mode, type: :array, values: ['all', 'spot', 'link']
     form_configurable :models, roles: :completable, cache_response: false
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_sesame_retrieve_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_sesame_retrieve_agent.rb
@@ -21,6 +21,8 @@ module Agents
 
       `inputDataType`: parameter that specifies the format in which the query is provided to the service. It can have four different values: `NIF`, `entity`, `sparql` or `triple`.
 
+      `merge` set to true to retain the received payload and update it with the extracted result
+
       **If the `inputDataType` is `NIF`, `entity` or `sparql`:**
 
       `input`: use [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid) templating to specify the data to be send to the API.
@@ -56,6 +58,7 @@ module Agents
     form_configurable :predicate
     form_configurable :object
     form_configurable :outformat, type: :array, values: ['text/turtle', 'application/json-ld', 'application/rdf-xml', 'text/html']
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -73,7 +76,7 @@ module Agents
           ['storageName', 'storagePath', 'inputDataFormat', 'input']
         end
 
-        nif_request!(mo, keys, mo['url'])
+        nif_request!(mo, keys, mo['url'], event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_sesame_retrieve_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_sesame_retrieve_agent.rb
@@ -21,7 +21,7 @@ module Agents
 
       `inputDataType`: parameter that specifies the format in which the query is provided to the service. It can have four different values: `NIF`, `entity`, `sparql` or `triple`.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
 
       **If the `inputDataType` is `NIF`, `entity` or `sparql`:**
 
@@ -58,7 +58,7 @@ module Agents
     form_configurable :predicate
     form_configurable :object
     form_configurable :outformat, type: :array, values: ['text/turtle', 'application/json-ld', 'application/rdf-xml', 'text/html']
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_sesame_store_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_sesame_store_agent.rb
@@ -23,7 +23,7 @@ module Agents
 
       `inputDataFormat`: parameter that specifies the format in which the information is provided to the service. It can have three different values: `body`, or `triple`.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
 
       **If the `inputDataFormat` is `body`:**
 
@@ -61,7 +61,7 @@ module Agents
     form_configurable :subject
     form_configurable :predicate
     form_configurable :object
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_sesame_store_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_sesame_store_agent.rb
@@ -23,6 +23,8 @@ module Agents
 
       `inputDataFormat`: parameter that specifies the format in which the information is provided to the service. It can have three different values: `body`, or `triple`.
 
+      `merge` set to true to retain the received payload and update it with the extracted result
+
       **If the `inputDataFormat` is `body`:**
 
       `body` use [Liquid](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid) templating to specify the data to be send to the API.
@@ -59,6 +61,7 @@ module Agents
     form_configurable :subject
     form_configurable :predicate
     form_configurable :object
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -79,7 +82,7 @@ module Agents
           ['storageName', 'storagePath', 'storageCreate', 'inputDataFormat', 'inputDataMimeType', 'subject', 'predicate', 'object']
         end
 
-        nif_request!(mo, keys, mo['url'])
+        nif_request!(mo, keys, mo['url'], event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_smt_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_smt_agent.rb
@@ -32,7 +32,7 @@ module Agents
           Spanish to English
           English to Spanish
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -51,7 +51,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['turtle', 'json-ld', 'n3', 'n-triples', 'rdf-xml', 'text/html']
     form_configurable :source_lang, type: :array, values: ['en','de', 'es']
     form_configurable :target_lang, type: :array, values: ['en','de', 'es']
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_smt_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_smt_agent.rb
@@ -31,6 +31,8 @@ module Agents
           English to German
           Spanish to English
           English to Spanish
+
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -49,6 +51,7 @@ module Agents
     form_configurable :outformat, type: :array, values: ['turtle', 'json-ld', 'n3', 'n-triples', 'rdf-xml', 'text/html']
     form_configurable :source_lang, type: :array, values: ['en','de', 'es']
     form_configurable :target_lang, type: :array, values: ['en','de', 'es']
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -60,7 +63,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['target_lang', 'source_lang'], mo['url'])
+        nif_request!(mo, ['target_lang', 'source_lang'], mo['url'], event: event)
       end
     end
   end

--- a/lib/huginn_dkt_curation_agents/dkt_topic_modelling_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_topic_modelling_agent.rb
@@ -33,7 +33,7 @@ module Agents
 
       `modelPath` [optional] this parameter is only used is other location for models is used inside the server. This parameter has been meant for local installation of the service.
 
-      `merge` set to true to retain the received payload and update it with the extracted result
+      #{common_nif_agent_fields_description}
     MD
 
     def default_options
@@ -55,7 +55,7 @@ module Agents
     form_configurable :language, type: :array, values: ['en','de']
     form_configurable :modelName, type: :array, values: ['3pc', 'concat', 'kreuzwerker']
     form_configurable :modelPath
-    form_configurable :merge, type: :boolean
+    common_nif_agent_fields
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?

--- a/lib/huginn_dkt_curation_agents/dkt_topic_modelling_agent.rb
+++ b/lib/huginn_dkt_curation_agents/dkt_topic_modelling_agent.rb
@@ -33,6 +33,7 @@ module Agents
 
       `modelPath` [optional] this parameter is only used is other location for models is used inside the server. This parameter has been meant for local installation of the service.
 
+      `merge` set to true to retain the received payload and update it with the extracted result
     MD
 
     def default_options
@@ -54,6 +55,7 @@ module Agents
     form_configurable :language, type: :array, values: ['en','de']
     form_configurable :modelName, type: :array, values: ['3pc', 'concat', 'kreuzwerker']
     form_configurable :modelPath
+    form_configurable :merge, type: :boolean
 
     def validate_options
       errors.add(:base, "url needs to be present") if options['url'].blank?
@@ -65,7 +67,7 @@ module Agents
       incoming_events.each do |event|
         mo = interpolated(event)
 
-        nif_request!(mo, ['outformat', 'modelName', 'input', 'informat', 'modelPath', 'language'], mo['url'])
+        nif_request!(mo, ['outformat', 'modelName', 'input', 'informat', 'modelPath', 'language'], mo['url'], event: event)
       end
     end
   end

--- a/spec/support/shared_examples/dkt_nif_api_agent_concern.rb
+++ b/spec/support/shared_examples/dkt_nif_api_agent_concern.rb
@@ -44,4 +44,27 @@ shared_examples_for DktNifApiAgentConcern do
       expect(event.payload[:some]).to eq('data')
     end
   end
+
+  context 'result_key' do
+    let(:event) { Event.new }
+
+    before do
+      stub_request(:any, //).
+         to_return(:status => 200, :body => '{"some": "json"}', :headers => {})
+    end
+
+    it 'emits the data in the payload root when not result_key is set' do
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:body]).not_to be_nil
+    end
+
+    it 'nests the data inside result_key when it is set' do
+      @checker.options['result_key'] = 'data'
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:body]).to be_nil
+      expect(event.payload[:data]).not_to be_nil
+    end
+  end
 end

--- a/spec/support/shared_examples/dkt_nif_api_agent_concern.rb
+++ b/spec/support/shared_examples/dkt_nif_api_agent_concern.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 shared_examples_for DktNifApiAgentConcern do
+  it 'renders the description wihtout errors' do
+    expect { @checker.description }.not_to raise_error
+  end
+
   it "event description does not throw an exception" do
     expect(@checker.event_description).to include('body')
   end

--- a/spec/support/shared_examples/dkt_nif_api_agent_concern.rb
+++ b/spec/support/shared_examples/dkt_nif_api_agent_concern.rb
@@ -22,4 +22,26 @@ shared_examples_for DktNifApiAgentConcern do
     mock(@checker).receive([event])
     @checker.check
   end
+
+  context '#merge' do
+    let(:event) { Event.new(payload: {some: 'data'}) }
+
+    before do
+      stub_request(:any, //).
+         to_return(:status => 200, :body => '{"some": "json"}', :headers => {})
+    end
+
+    it 'does not merge the received event into the result per default' do
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:some]).to be_nil
+    end
+
+    it 'merges the results with the received event when merge is set to true' do
+      @checker.options['merge'] = "true"
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      event = Event.last
+      expect(event.payload[:some]).to eq('data')
+    end
+  end
 end


### PR DESCRIPTION
When `merge` is set to true the received event will be merged into the emitted data
